### PR TITLE
Fix typo: 'Documenatation' → 'Documentation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Options:
 
 Check out the documentation for noskey in the docs directory. There, you can find more detailed information about the features and usage of this tool.
 
-[Documenatation](https://melvincarvalho.github.io/noskey/docs/)
+[Documentation](https://melvincarvalho.github.io/noskey/docs/)
 
 ## ⚖️ License
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -138,7 +138,7 @@ Options:
 </code></pre>
 <h2>📚 Documentation</h2>
 <p>Check out the documentation for noskey in the docs directory. There, you can find more detailed information about the features and usage of this tool.</p>
-<p><a href="https://melvincarvalho.github.io/noskey/docs/">Documenatation</a></p>
+<p><a href="https://melvincarvalho.github.io/noskey/docs/">Documentation</a></p>
 <h2>⚖️ License</h2>
 <p>This project is under the MIT License. See the <a href="https://github.com/melvincarvalho/noskey/blob/gh-pages/LICENSE">LICENSE</a> file for the full license text.</p></article>
     </section>


### PR DESCRIPTION
## Summary
- Fix typo in README.md and docs/index.html where "Documentation" was misspelled as "Documenatation"

## Test plan
- [x] Verify spelling is correct in both files

Fixes #4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a misspelling in public-facing docs.
> 
> - Corrects link text from `Documenatation` to `Documentation` in `README.md` and `docs/index.html`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8fb1b147adf1e571fa10f3976610e51acad7536. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->