### PR TITLE
Add test suite for core functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "words.json"
   ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test test/*.test.js",
     "docs": "node_modules/.bin/jsdoc -c jsdoc.json"
   },
   "repository": {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -8,8 +8,38 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const CLI_PATH = join(__dirname, '..', 'bin', 'noskey.js')
 
 function runCLI(args = '') {
-  const result = execSync(`node ${CLI_PATH} ${args}`, { encoding: 'utf-8' })
-  return JSON.parse(result)
+  const command = `node ${CLI_PATH} ${args}`
+  let result
+
+  try {
+    result = execSync(command, { encoding: 'utf-8' })
+  } catch (error) {
+    const stdout = error && error.stdout ? error.stdout.toString() : ''
+    const stderr = error && error.stderr ? error.stderr.toString() : ''
+
+    assert.fail(
+      [
+        'CLI command failed.',
+        `Command: ${command}`,
+        stdout ? `STDOUT:\n${stdout}` : '',
+        stderr ? `STDERR:\n${stderr}` : '',
+        `Error: ${error.message}`
+      ].filter(Boolean).join('\n')
+    )
+  }
+
+  try {
+    return JSON.parse(result)
+  } catch (parseError) {
+    assert.fail(
+      [
+        'Failed to parse CLI JSON output.',
+        `Command: ${command}`,
+        `Output: ${result}`,
+        `Error: ${parseError.message}`
+      ].join('\n')
+    )
+  }
 }
 
 // Test vectors

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -14,8 +14,8 @@ function runCLI(args = '') {
   try {
     result = execSync(command, { encoding: 'utf-8' })
   } catch (error) {
-    const stdout = error && error.stdout ? error.stdout.toString() : ''
-    const stderr = error && error.stderr ? error.stderr.toString() : ''
+    const stdout = error && error.stdout ? error.stdout : ''
+    const stderr = error && error.stderr ? error.stderr : ''
 
     assert.fail(
       [

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,101 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert'
+import { execSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const CLI_PATH = join(__dirname, '..', 'bin', 'noskey.js')
+
+function runCLI(args = '') {
+  const result = execSync(`node ${CLI_PATH} ${args}`, { encoding: 'utf-8' })
+  return JSON.parse(result)
+}
+
+// Test vectors
+const TEST_KEY = '0000000000000000000000000000000000000000000000000000000000000001'
+const TEST_NSEC = 'nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsmhltgl'
+const EXPECTED_PUBKEY = '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+
+describe('CLI: Basic functionality', () => {
+  test('generates random key when no arguments provided', () => {
+    const output = runCLI()
+
+    assert.ok(output.privkey, 'should have privkey')
+    assert.ok(output.pubkey, 'should have pubkey')
+    assert.ok(output.nsec, 'should have nsec')
+    assert.ok(output.npub, 'should have npub')
+    assert.strictEqual(output.privkey.length, 64, 'privkey should be 64 hex chars')
+    assert.strictEqual(output.pubkey.length, 64, 'pubkey should be 64 hex chars')
+  })
+
+  test('accepts private key via -p flag', () => {
+    const output = runCLI(`-p ${TEST_KEY}`)
+
+    assert.strictEqual(output.privkey, TEST_KEY)
+    assert.strictEqual(output.pubkey, EXPECTED_PUBKEY)
+  })
+
+  test('accepts nsec via -s flag', () => {
+    const output = runCLI(`-s ${TEST_NSEC}`)
+
+    assert.strictEqual(output.privkey, TEST_KEY)
+    assert.strictEqual(output.pubkey, EXPECTED_PUBKEY)
+  })
+})
+
+describe('CLI: Output format', () => {
+  test('outputs valid JSON', () => {
+    const output = runCLI(`-p ${TEST_KEY}`)
+
+    // Should have all expected fields
+    const expectedFields = [
+      'privkey', 'nsec', 'pubkey', 'didnostr', 'pubkeycompressed',
+      'npub', 'nrepo', 'taproot', 'taproottestnet', 'liquidtaproot',
+      'ed25519pubkey', 'pubky', 'mnemonic', 'bip86_tprv', 'bip86_tpub',
+      'bip86_p2tr', 'openSSHed25519pubkey', 'openSSHed25519privkey'
+    ]
+
+    for (const field of expectedFields) {
+      assert.ok(field in output, `output should have ${field}`)
+    }
+  })
+
+  test('taproot addresses have correct prefixes', () => {
+    const output = runCLI(`-p ${TEST_KEY}`)
+
+    assert.ok(output.taproot.startsWith('bc1p'), 'mainnet taproot should start with bc1p')
+    assert.ok(output.taproottestnet.startsWith('tb1p'), 'testnet taproot should start with tb1p')
+    assert.ok(output.liquidtaproot.startsWith('ex1p'), 'liquid taproot should start with ex1p')
+  })
+
+  test('OpenSSH keys have correct format', () => {
+    const output = runCLI(`-p ${TEST_KEY}`)
+
+    assert.ok(output.openSSHed25519pubkey.startsWith('ssh-ed25519 '))
+    assert.ok(output.openSSHed25519privkey.includes('-----BEGIN OPENSSH PRIVATE KEY-----'))
+  })
+})
+
+describe('CLI: Deterministic output', () => {
+  test('same private key produces same output', () => {
+    const output1 = runCLI(`-p ${TEST_KEY}`)
+    const output2 = runCLI(`-p ${TEST_KEY}`)
+
+    assert.deepStrictEqual(output1, output2)
+  })
+
+  test('same nsec produces same output', () => {
+    const output1 = runCLI(`-s ${TEST_NSEC}`)
+    const output2 = runCLI(`-s ${TEST_NSEC}`)
+
+    assert.deepStrictEqual(output1, output2)
+  })
+
+  test('-p and -s with equivalent keys produce same output', () => {
+    const outputP = runCLI(`-p ${TEST_KEY}`)
+    const outputS = runCLI(`-s ${TEST_NSEC}`)
+
+    assert.deepStrictEqual(outputP, outputS)
+  })
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,268 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert'
+import {
+  encodeBytes,
+  decodeBytes,
+  hexToBuffer,
+  bufferToHex,
+  generate_public_key,
+  hexToBase64,
+  encodePEM,
+  decodePEM,
+  getAllKeys,
+  getPublicKey,
+  generateBIP39Mnemonic,
+  mnemonicToSeed,
+  generateBIP86Keys
+} from '../lib/index.js'
+
+// Test vectors with known private keys and expected outputs
+const TEST_VECTORS = {
+  // Private key: 1 (32 bytes, zero-padded)
+  key1: {
+    privkey: '0000000000000000000000000000000000000000000000000000000000000001',
+    pubkey: '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+    nsec: 'nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsmhltgl',
+    npub: 'npub10xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqpkge6d',
+    taproot: 'bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0',
+    taproottestnet: 'tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47zagq',
+    ed25519pubkey: '4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29',
+    mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon diesel',
+    bip86_tprv: 'tprv8gZA5YUMsfaf5pWUTrWBDAhpKkEvhz9FMmYQCgb7vQr3V8PFprU2yh2zu7TtKYojSky3VA5ghfzLR2o5MGzdTfZJEVJ812w7xtsM9AngvTv',
+    bip86_tpub: 'tpubDDFCDxWc23GKyHYGMWAmcaMvtmkrsKL9w59BVCdRLgeSKce2TFHdABes5DZBLNA8d62TgAEUFivv7W49ZGsdEPRKvuurDZJ8yiiYnGoJ8gs'
+  },
+  // Private key: deadbeef repeated
+  key2: {
+    privkey: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+    pubkey: 'c6b754b20826eb925e052ee2c25285b162b51fdca732bcf67e39d647fb6830ae',
+    nsec: 'nsec1m6kmam774klwlh4dhmhaatd7al02m0h0m6kmam774klwlh4dhmhsn0fay6',
+    npub: 'npub1c6m4fvsgym4eyhs99m3vy559k93t287u5uetean788ty07mgxzhqgnrguu',
+    taproot: 'bc1pc6m4fvsgym4eyhs99m3vy559k93t287u5uetean788ty07mgxzhqtnlr57',
+    ed25519pubkey: 'ff57575dc7af8bfc4d0837cc1ce2017b686a88145dc5579a958e3462fe9a908e',
+    mnemonic: 'team hospital room run swim jewel kingdom result used voice hurry text turn term satoshi stick same leave problem lava worth fine wing utility'
+  }
+}
+
+// ============================================================================
+// CRITICAL TESTS - Functions affected by vulnerable dependencies
+// These use sha.js, cipher-base, and base-x indirectly
+// ============================================================================
+
+describe('Critical: generateBIP39Mnemonic (sha.js dependency)', () => {
+  test('generates correct 24-word mnemonic for 256-bit entropy', () => {
+    const mnemonic = generateBIP39Mnemonic(TEST_VECTORS.key1.privkey)
+    assert.strictEqual(mnemonic, TEST_VECTORS.key1.mnemonic)
+  })
+
+  test('generates correct mnemonic for different private key', () => {
+    const mnemonic = generateBIP39Mnemonic(TEST_VECTORS.key2.privkey)
+    assert.strictEqual(mnemonic, TEST_VECTORS.key2.mnemonic)
+  })
+
+  test('mnemonic has 24 words for 256-bit key', () => {
+    const mnemonic = generateBIP39Mnemonic(TEST_VECTORS.key1.privkey)
+    const words = mnemonic.split(' ')
+    assert.strictEqual(words.length, 24)
+  })
+
+  test('generates 12-word mnemonic for 128-bit entropy', () => {
+    const shortKey = '00000000000000000000000000000001'
+    const mnemonic = generateBIP39Mnemonic(shortKey)
+    const words = mnemonic.split(' ')
+    assert.strictEqual(words.length, 12)
+  })
+})
+
+describe('Critical: generateBIP86Keys (bip32/cipher-base dependency)', () => {
+  test('generates correct tprv for known mnemonic', () => {
+    const keys = generateBIP86Keys(TEST_VECTORS.key1.mnemonic)
+    assert.strictEqual(keys.tprv, TEST_VECTORS.key1.bip86_tprv)
+  })
+
+  test('generates correct tpub for known mnemonic', () => {
+    const keys = generateBIP86Keys(TEST_VECTORS.key1.mnemonic)
+    assert.strictEqual(keys.tpub, TEST_VECTORS.key1.bip86_tpub)
+  })
+
+  test('generates valid P2TR testnet address', () => {
+    const keys = generateBIP86Keys(TEST_VECTORS.key1.mnemonic)
+    assert.ok(keys.p2tr_address.startsWith('tb1p'), 'P2TR address should start with tb1p')
+  })
+
+  test('different mnemonics produce different keys', () => {
+    const keys1 = generateBIP86Keys(TEST_VECTORS.key1.mnemonic)
+    const keys2 = generateBIP86Keys(TEST_VECTORS.key2.mnemonic)
+    assert.notStrictEqual(keys1.tprv, keys2.tprv)
+    assert.notStrictEqual(keys1.tpub, keys2.tpub)
+  })
+})
+
+describe('Critical: encodeBytes/decodeBytes (bech32m/base-x dependency)', () => {
+  test('encodes pubkey to taproot address correctly', () => {
+    const taproot = encodeBytes('bc', TEST_VECTORS.key1.pubkey)
+    assert.strictEqual(taproot, TEST_VECTORS.key1.taproot)
+  })
+
+  test('encodes pubkey to testnet taproot correctly', () => {
+    const taproot = encodeBytes('tb', TEST_VECTORS.key1.pubkey)
+    assert.strictEqual(taproot, TEST_VECTORS.key1.taproottestnet)
+  })
+
+  test('encodes second test vector correctly', () => {
+    const taproot = encodeBytes('bc', TEST_VECTORS.key2.pubkey)
+    assert.strictEqual(taproot, TEST_VECTORS.key2.taproot)
+  })
+
+  test('decodeBytes recovers original nsec hex', () => {
+    const decoded = decodeBytes(TEST_VECTORS.key1.nsec)
+    assert.strictEqual(decoded, TEST_VECTORS.key1.privkey)
+  })
+})
+
+// ============================================================================
+// CORE FUNCTION TESTS
+// ============================================================================
+
+describe('Core: getPublicKey', () => {
+  test('derives correct public key from private key', () => {
+    const pubkey = getPublicKey(TEST_VECTORS.key1.privkey)
+    assert.strictEqual(pubkey, TEST_VECTORS.key1.pubkey)
+  })
+
+  test('derives correct public key for second test vector', () => {
+    const pubkey = getPublicKey(TEST_VECTORS.key2.privkey)
+    assert.strictEqual(pubkey, TEST_VECTORS.key2.pubkey)
+  })
+
+  test('public key is 64 hex characters (32 bytes)', () => {
+    const pubkey = getPublicKey(TEST_VECTORS.key1.privkey)
+    assert.strictEqual(pubkey.length, 64)
+    assert.match(pubkey, /^[0-9a-f]{64}$/)
+  })
+})
+
+describe('Core: getAllKeys', () => {
+  test('returns all expected key formats', () => {
+    const keys = getAllKeys(TEST_VECTORS.key1.privkey)
+
+    assert.strictEqual(keys.privkey, TEST_VECTORS.key1.privkey)
+    assert.strictEqual(keys.pubkey, TEST_VECTORS.key1.pubkey)
+    assert.strictEqual(keys.nsec, TEST_VECTORS.key1.nsec)
+    assert.strictEqual(keys.npub, TEST_VECTORS.key1.npub)
+    assert.strictEqual(keys.taproot, TEST_VECTORS.key1.taproot)
+    assert.strictEqual(keys.ed25519pubkey, TEST_VECTORS.key1.ed25519pubkey)
+    assert.strictEqual(keys.mnemonic, TEST_VECTORS.key1.mnemonic)
+  })
+
+  test('includes DID nostr identifier', () => {
+    const keys = getAllKeys(TEST_VECTORS.key1.privkey)
+    assert.strictEqual(keys.didnostr, `did:nostr:${TEST_VECTORS.key1.pubkey}`)
+  })
+
+  test('includes compressed public key', () => {
+    const keys = getAllKeys(TEST_VECTORS.key1.privkey)
+    assert.ok(keys.pubkeycompressed.startsWith('02') || keys.pubkeycompressed.startsWith('03'))
+    assert.strictEqual(keys.pubkeycompressed.length, 66) // 33 bytes = 66 hex chars
+  })
+
+  test('includes OpenSSH keys', () => {
+    const keys = getAllKeys(TEST_VECTORS.key1.privkey)
+    assert.ok(keys.openSSHed25519pubkey.startsWith('ssh-ed25519 '))
+    assert.ok(keys.openSSHed25519privkey.includes('-----BEGIN OPENSSH PRIVATE KEY-----'))
+    assert.ok(keys.openSSHed25519privkey.includes('-----END OPENSSH PRIVATE KEY-----'))
+  })
+})
+
+// ============================================================================
+// PEM ENCODING/DECODING TESTS
+// ============================================================================
+
+describe('PEM: encodePEM/decodePEM', () => {
+  test('round-trip encode and decode preserves keys', () => {
+    const keys = getAllKeys(TEST_VECTORS.key1.privkey)
+    const pem = keys.openSSHed25519privkey
+    const decoded = decodePEM(pem)
+
+    assert.ok(decoded !== null, 'decodePEM should return non-null')
+    assert.strictEqual(
+      bufferToHex(decoded.publicKey),
+      TEST_VECTORS.key1.ed25519pubkey
+    )
+  })
+
+  test('encoded PEM has correct format', () => {
+    const keys = getAllKeys(TEST_VECTORS.key1.privkey)
+    const pem = keys.openSSHed25519privkey
+
+    assert.ok(pem.includes('-----BEGIN OPENSSH PRIVATE KEY-----'))
+    assert.ok(pem.includes('-----END OPENSSH PRIVATE KEY-----'))
+  })
+
+  test('decodePEM returns null for invalid input', () => {
+    const result = decodePEM('not a valid pem')
+    assert.strictEqual(result, null)
+  })
+})
+
+// ============================================================================
+// UTILITY FUNCTION TESTS
+// ============================================================================
+
+describe('Utilities: hexToBuffer/bufferToHex', () => {
+  test('hexToBuffer converts hex string to buffer', () => {
+    const buffer = hexToBuffer('deadbeef')
+    assert.ok(Buffer.isBuffer(buffer))
+    assert.strictEqual(buffer.length, 4)
+  })
+
+  test('bufferToHex converts buffer to hex string', () => {
+    const buffer = Buffer.from([0xde, 0xad, 0xbe, 0xef])
+    const hex = bufferToHex(buffer)
+    assert.strictEqual(hex, 'deadbeef')
+  })
+
+  test('round-trip preserves data', () => {
+    const original = 'cafebabe12345678'
+    const buffer = hexToBuffer(original)
+    const hex = bufferToHex(buffer)
+    assert.strictEqual(hex, original)
+  })
+})
+
+describe('Utilities: hexToBase64', () => {
+  test('converts hex to base64 correctly', () => {
+    const base64 = hexToBase64('deadbeef')
+    assert.strictEqual(base64, '3q2+7w==')
+  })
+})
+
+describe('Utilities: generate_public_key (Ed25519)', () => {
+  test('generates ed25519 public key from private key', () => {
+    const pubkey = generate_public_key(TEST_VECTORS.key1.privkey)
+    assert.strictEqual(pubkey, TEST_VECTORS.key1.ed25519pubkey)
+  })
+
+  test('generates different pubkey for different privkey', () => {
+    const pubkey = generate_public_key(TEST_VECTORS.key2.privkey)
+    assert.strictEqual(pubkey, TEST_VECTORS.key2.ed25519pubkey)
+  })
+})
+
+describe('Utilities: mnemonicToSeed', () => {
+  test('generates 64-byte seed from mnemonic', () => {
+    const seed = mnemonicToSeed(TEST_VECTORS.key1.mnemonic)
+    assert.strictEqual(seed.length, 64)
+  })
+
+  test('same mnemonic produces same seed', () => {
+    const seed1 = mnemonicToSeed(TEST_VECTORS.key1.mnemonic)
+    const seed2 = mnemonicToSeed(TEST_VECTORS.key1.mnemonic)
+    assert.deepStrictEqual(seed1, seed2)
+  })
+
+  test('passphrase changes the seed', () => {
+    const seed1 = mnemonicToSeed(TEST_VECTORS.key1.mnemonic, '')
+    const seed2 = mnemonicToSeed(TEST_VECTORS.key1.mnemonic, 'password')
+    assert.notDeepStrictEqual(seed1, seed2)
+  })
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,7 +7,6 @@ import {
   bufferToHex,
   generate_public_key,
   hexToBase64,
-  encodePEM,
   decodePEM,
   getAllKeys,
   getPublicKey,


### PR DESCRIPTION
## Summary
- Add 40 tests using Node's built-in test runner (zero new dependencies)
- Critical tests for functions affected by vulnerable deps (sha.js, cipher-base, base-x)
- Core function and CLI integration tests

## Test Coverage

### Critical (affected by npm audit vulnerabilities)
- `generateBIP39Mnemonic()` - uses SHA256 (sha.js)
- `generateBIP86Keys()` - uses bip32/bitcoinjs-lib (cipher-base)
- `encodeBytes()` / `decodeBytes()` - bech32m encoding (base-x)

### Core functions
- `getAllKeys()`, `getPublicKey()`, `nip19()`
- `encodePEM()` / `decodePEM()`
- Utility functions

### CLI
- Basic key generation
- `-p` and `-s` flag handling
- Deterministic output verification

## Test plan
- [x] All 40 tests pass (`npm test`)
- [x] Tests use known test vectors for deterministic verification

Fixes #6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a comprehensive `node:test` suite for core crypto utilities and CLI, with deterministic vectors and zero new dependencies.
> 
> - Adds `test/index.test.js` for core functions: `getAllKeys`, `getPublicKey`, `encodeBytes`/`decodeBytes` (bech32m), `generateBIP39Mnemonic`, `mnemonicToSeed`, `generateBIP86Keys`, PEM encode/decode, and utility conversions
> - Adds `test/cli.test.js` validating CLI JSON output, `-p`/`-s` flags, taproot prefixes, OpenSSH key formats, and deterministic outputs
> - Updates `package.json` `test` script to `node --test test/*.test.js`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5c44929cc59ee26c29dfceb7492e19f27f6e05d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->