### PR TITLE
Document the missing -n/--npub option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Usage: noskey [options]
 Options:
       --version  Show version number
   -v, --vanity   Vanity string
+  -n, --npub     npub Vanity string
   -p, --priv     Private key
   -s, --nsec     From nsec
   -h, --help     Show help


### PR DESCRIPTION
`bin/noskey.js` defines `-n, --npub` ("npub Vanity string") but the README Options help block listed only `-v/-p/-s/-h`. Added the `-n, --npub` line so the docs match the CLI.