### PR TITLE
Add pubkey-only mode to lib, CLI and web

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Generate a from private key
 npx noskey -p 123
 ```
 
+Show the publicly derivable fields of a public key (hex or npub)
+
+```bash
+npx noskey --pub npub1xyz2l5auvptxt50f9t7uxwa4pkxcc3ef8ytrwn6949jlcwg2qvesle5tfn
+```
+
 Install locally
 
 ```bash
@@ -85,6 +91,7 @@ Options:
   -n, --npub     npub Vanity string
   -p, --priv     Private key
   -s, --nsec     From nsec
+      --pub      Public key (hex or npub) — output only publicly derivable fields
   -h, --help     Show help
 ```
 

--- a/bin/noskey.js
+++ b/bin/noskey.js
@@ -4,6 +4,7 @@
 import { generatePrivateKey } from 'nostr-tools'
 import {
 	getAllKeys,
+	getPubKeys,
 	decodeBytes
 } from '../lib/index.js'
 import yargs from 'yargs'
@@ -35,6 +36,10 @@ const argv = yarg
 		describe: 'nsec private key',
 		type: 'string'
 	})
+	.option('pub', {
+		describe: 'Public key (hex or npub) — output only publicly derivable fields',
+		type: 'string'
+	})
 	.help('h')
 	.alias('h', 'help').argv
 
@@ -43,6 +48,13 @@ const argv = yarg
 const vanity = argv.v || ''
 const npubvanity = argv.n || ''
 const nsec = argv.s
+
+// Public-key-only mode: output the subset derivable without a private key
+if (argv.pub) {
+	const publicKey = argv.pub.startsWith('npub1') ? decodeBytes(argv.pub) : argv.pub
+	console.log(JSON.stringify(getPubKeys(publicKey), null, 2))
+	process.exit(0)
+}
 
 // If no specific key provided and no vanity requirements, just generate one key
 if (!nsec && !argv.p && !vanity && !npubvanity) {

--- a/bin/noskey.js
+++ b/bin/noskey.js
@@ -51,9 +51,14 @@ const nsec = argv.s
 
 // Public-key-only mode: output the subset derivable without a private key
 if (argv.pub) {
-	const publicKey = argv.pub.startsWith('npub1') ? decodeBytes(argv.pub) : argv.pub
-	console.log(JSON.stringify(getPubKeys(publicKey), null, 2))
-	process.exit(0)
+	try {
+		const publicKey = argv.pub.startsWith('npub1') ? decodeBytes(argv.pub) : argv.pub
+		console.log(JSON.stringify(getPubKeys(publicKey), null, 2))
+		process.exit(0)
+	} catch (error) {
+		console.error(error.message)
+		process.exit(1)
+	}
 }
 
 // If no specific key provided and no vanity requirements, just generate one key

--- a/lib/index.js
+++ b/lib/index.js
@@ -762,6 +762,10 @@ function getAllKeys(privateKey) {
  * @returns {Object} The subset of getAllKeys() output derivable from the public key.
  */
 function getPubKeys(publicKey) {
+  publicKey = String(publicKey).toLowerCase()
+  if (!/^[0-9a-f]{64}$/.test(publicKey)) {
+    throw new Error('Invalid public key: expected 32-byte (64 hex chars) x-only key')
+  }
   const taproot_prefix = 'bc'
   const taproot_testnet_prefix = 'tb'
   const liquid_prefix = 'ex'

--- a/lib/index.js
+++ b/lib/index.js
@@ -751,6 +751,36 @@ function getAllKeys(privateKey) {
   return output
 }
 
+/**
+ * Generates every key and address derivable from an x-only public key alone.
+ *
+ * Note: the compressed public key is deliberately omitted — the y-parity is
+ * unknown from an x-only key, so guessing 02 would silently differ from
+ * getAllKeys() for roughly half of all keys.
+ *
+ * @param {string} publicKey - The x-only public key in hex.
+ * @returns {Object} The subset of getAllKeys() output derivable from the public key.
+ */
+function getPubKeys(publicKey) {
+  const taproot_prefix = 'bc'
+  const taproot_testnet_prefix = 'tb'
+  const liquid_prefix = 'ex'
+  const litecoin_prefix = 'ltc'
+  const vertcoin_prefix = 'vtc'
+
+  return {
+    pubkey: publicKey,
+    didnostr: `did:nostr:${publicKey}`,
+    npub: nip19(publicKey, 'npub'),
+    nrepo: nip19(publicKey, 'nrepo'),
+    taproot: encodeBytes(taproot_prefix, publicKey),
+    taproottestnet: encodeBytes(taproot_testnet_prefix, publicKey),
+    liquidtaproot: encodeBytes(liquid_prefix, publicKey),
+    litecointaproot: encodeBytes(litecoin_prefix, publicKey),
+    vertcointaproot: encodeBytes(vertcoin_prefix, publicKey)
+  }
+}
+
 export {
   encodeBytes,
   decodeBytes,
@@ -762,6 +792,7 @@ export {
   encodePEM,
   decodePEM,
   getAllKeys,
+  getPubKeys,
   getPublicKey,
   generateBIP39Mnemonic,
   mnemonicToSeed,

--- a/test/verify-core.js
+++ b/test/verify-core.js
@@ -45,8 +45,35 @@ for (const key of KEYS) {
   }
 }
 
+// --- pubkey-only mode: web core vs CLI --pub, and consistency with getAllKeys
+for (const key of KEYS) {
+  const all = noskey.getAllKeys(key);
+
+  // web core vs CLI --pub (fed the derived pubkey, as hex and as npub)
+  for (const pubInput of [all.pubkey, all.npub]) {
+    const cli = JSON.parse(execFileSync("node", ["bin/noskey.js", "--pub", pubInput], { encoding: "utf8" }));
+    const web = noskey.getPubKeys(all.pubkey);
+    const fields = new Set([...Object.keys(cli), ...Object.keys(web)]);
+    const bad = [...fields].filter((f) => cli[f] !== web[f]);
+    if (bad.length) {
+      failures++;
+      console.log(`FAIL  --pub ${pubInput.slice(0, 14)}…  mismatched: ${bad.join(", ")}`);
+    } else {
+      console.log(`PASS  --pub ${pubInput.slice(0, 14)}…  (${fields.size} fields match)`);
+    }
+  }
+
+  // every getPubKeys field must equal the same field in getAllKeys
+  const pub = noskey.getPubKeys(all.pubkey);
+  const drift = Object.keys(pub).filter((f) => pub[f] !== all[f]);
+  if (drift.length) {
+    failures++;
+    console.log(`FAIL  getPubKeys drift vs getAllKeys: ${drift.join(", ")}`);
+  }
+}
+
 if (failures) {
-  console.error(`\n${failures} key(s) mismatched the CLI.`);
+  console.error(`\n${failures} check(s) mismatched the CLI.`);
   process.exit(1);
 }
 console.log("\nAll keys match the CLI exactly. ✅");

--- a/test/verify-core.js
+++ b/test/verify-core.js
@@ -72,6 +72,27 @@ for (const key of KEYS) {
   }
 }
 
+// --- getPubKeys input validation: uppercase normalizes, junk throws
+{
+  const all = noskey.getAllKeys(KEYS[0]);
+  const upper = noskey.getPubKeys(all.pubkey.toUpperCase());
+  if (upper.npub !== all.npub) {
+    failures++;
+    console.log("FAIL  uppercase pubkey not normalized");
+  } else {
+    console.log("PASS  uppercase pubkey normalized");
+  }
+  for (const junk of ["beef", all.pubkey + "00", "z".repeat(64)]) {
+    try {
+      noskey.getPubKeys(junk);
+      failures++;
+      console.log(`FAIL  getPubKeys accepted invalid input: ${junk.slice(0, 20)}`);
+    } catch {
+      console.log(`PASS  getPubKeys rejects ${junk.slice(0, 20)}`);
+    }
+  }
+}
+
 if (failures) {
   console.error(`\n${failures} check(s) mismatched the CLI.`);
   process.exit(1);

--- a/test/verify-core.js
+++ b/test/verify-core.js
@@ -91,6 +91,20 @@ for (const key of KEYS) {
       console.log(`PASS  getPubKeys rejects ${junk.slice(0, 20)}`);
     }
   }
+  // npubToHex must reject wrong HRPs (an nsec is valid bech32 but not an npub)
+  if (noskey.npubToHex(all.npub) !== all.pubkey) {
+    failures++;
+    console.log("FAIL  npubToHex round-trip");
+  } else {
+    console.log("PASS  npubToHex round-trip");
+  }
+  try {
+    noskey.npubToHex(all.nsec);
+    failures++;
+    console.log("FAIL  npubToHex accepted an nsec");
+  } catch {
+    console.log("PASS  npubToHex rejects non-npub HRP");
+  }
 }
 
 if (failures) {

--- a/web/assets/noskey-core.js
+++ b/web/assets/noskey-core.js
@@ -245,6 +245,30 @@ export function createNoskey(deps) {
     return nip19(getPublicKey(privateKeyHex), "npub");
   }
 
+  // Everything derivable from an x-only public key alone (mirrors lib's
+  // getPubKeys). Compressed pubkey is omitted: y-parity is unknown from an
+  // x-only key, so guessing 02 would differ from getAllKeys for ~half of keys.
+  function getPubKeys(publicKey) {
+    return {
+      pubkey: publicKey,
+      didnostr: `did:nostr:${publicKey}`,
+      npub: nip19(publicKey, "npub"),
+      nrepo: nip19(publicKey, "nrepo"),
+      taproot: encodeBytes("bc", publicKey),
+      taproottestnet: encodeBytes("tb", publicKey),
+      liquidtaproot: encodeBytes("ex", publicKey),
+      litecointaproot: encodeBytes("ltc", publicKey),
+      vertcointaproot: encodeBytes("vtc", publicKey),
+    };
+  }
+
+  // Decode an npub to the x-only public key hex.
+  function npubToHex(npub) {
+    const { words } = bech32.decode(npub);
+    const data = bech32.fromWords(words);
+    return data.map((b) => b.toString(16).padStart(2, "0")).join("");
+  }
+
   // Deterministic 12-word BIP39 phrase from the first 128 bits of the private
   // key. NOT part of getAllKeys()/the CLI — a web-only convenience. One-way:
   // it encodes only the first half of the key, so it cannot restore the key.
@@ -252,5 +276,5 @@ export function createNoskey(deps) {
     return entropyToMnemonic(hexToBytes(privateKeyHex).slice(0, 16), wordlist);
   }
 
-  return { getAllKeys, getPublicKey, generatePrivateKey, nsecToHex, npubFromPrivate, mnemonic12 };
+  return { getAllKeys, getPubKeys, getPublicKey, generatePrivateKey, nsecToHex, npubToHex, npubFromPrivate, mnemonic12 };
 }

--- a/web/assets/noskey-core.js
+++ b/web/assets/noskey-core.js
@@ -268,8 +268,14 @@ export function createNoskey(deps) {
 
   // Decode an npub to the x-only public key hex.
   function npubToHex(npub) {
-    const { words } = bech32.decode(npub);
+    const { prefix, words } = bech32.decode(npub);
+    if (prefix !== "npub") {
+      throw new Error(`Expected an npub, got "${prefix}1…"`);
+    }
     const data = bech32.fromWords(words);
+    if (data.length !== 32) {
+      throw new Error(`Invalid npub payload: expected 32 bytes, got ${data.length}`);
+    }
     return data.map((b) => b.toString(16).padStart(2, "0")).join("");
   }
 

--- a/web/assets/noskey-core.js
+++ b/web/assets/noskey-core.js
@@ -249,6 +249,10 @@ export function createNoskey(deps) {
   // getPubKeys). Compressed pubkey is omitted: y-parity is unknown from an
   // x-only key, so guessing 02 would differ from getAllKeys for ~half of keys.
   function getPubKeys(publicKey) {
+    publicKey = String(publicKey).toLowerCase();
+    if (!/^[0-9a-f]{64}$/.test(publicKey)) {
+      throw new Error("Invalid public key: expected 32-byte (64 hex chars) x-only key");
+    }
     return {
       pubkey: publicKey,
       didnostr: `did:nostr:${publicKey}`,

--- a/web/index.html
+++ b/web/index.html
@@ -353,14 +353,20 @@ $("copy-json").addEventListener("click", (e) => { if (lastKeys) copy(JSON.string
 // (Public keys only: never accept secrets via URL — they leak into history/logs.)
 goEl.disabled = false; goEl.textContent = "Generate";
 const qpub = new URLSearchParams(location.search).get("pubkey");
-if (qpub && (/^[0-9a-fA-F]{64}$/.test(qpub) || /^npub1[0-9a-z]+$/.test(qpub))) {
+if (qpub) {
+  // A share link must never silently fall through to random generation —
+  // surface bad values instead of showing unrelated keys.
   try {
-    // Normalize the input box to the npub form: a raw 64-hex value would
-    // re-classify as a private key on the next Derive press and leak into
-    // getAllKeys — npub is unambiguous, so re-deriving stays public.
+    if (!/^[0-9a-fA-F]{64}$/.test(qpub) && !/^npub1[0-9a-z]+$/.test(qpub)) {
+      throw new Error("expected a 64-char hex pubkey or npub1…");
+    }
+    // Normalize the input box (and URL) to the npub form: a raw 64-hex value
+    // would re-classify as a private key on the next Derive press and leak
+    // into getAllKeys — npub is unambiguous, so re-deriving stays public.
     const hex = /^npub1/.test(qpub) ? noskey.npubToHex(qpub) : qpub.toLowerCase();
     const npub = noskey.getPubKeys(hex).npub;
     inputEl.value = npub;
+    if (qpub !== npub) history.replaceState(null, "", "?pubkey=" + npub);
     goEl.textContent = "Derive";
     generateFrom({ mode: "pub", value: npub });
   } catch (e) {

--- a/web/index.html
+++ b/web/index.html
@@ -129,11 +129,12 @@
 
   <div class="controls">
     <input type="text" id="input" autocomplete="off" autocapitalize="off" spellcheck="false"
-      placeholder="empty = random  ·  or a privkey / nsec / vanity prefix" />
+      placeholder="empty = random  ·  or a privkey / nsec / npub / vanity prefix" />
     <button class="primary" id="go" disabled>Loading…</button>
   </div>
   <p class="hint">Leave it empty and hit <b>Generate</b> for a fresh random key. Or paste a 64-char hex
-    <code>privkey</code>, an <code>nsec1…</code>, or type a short prefix (e.g. <code>sat</code>) to mine a vanity npub.</p>
+    <code>privkey</code>, an <code>nsec1…</code>, an <code>npub1…</code> (public fields only),
+    or type a short prefix (e.g. <code>sat</code>) to mine a vanity npub.</p>
 
   <div class="miner" id="miner">
     <div class="miner-head"><span class="spinner"></span> Mining for <code id="miner-target"></code>…</div>
@@ -224,13 +225,22 @@ async function copy(text, btn) {
 function render(keys, command) {
   cmdEl.innerHTML = `<span class="sigil">$</span> ${command}`;
   // Web-only derived fields, kept out of the CLI-mirrored JSON below.
-  const display = { ...keys, mnemonic12: noskey.mnemonic12(keys.privkey) };
+  const display = { ...keys };
+  if (keys.privkey) display.mnemonic12 = noskey.mnemonic12(keys.privkey);
   for (const k in fieldEls) {
     const val = display[k] ?? "";
     const v = fieldEls[k];
     v.dataset.full = val;
     v.textContent = val.length > 200 ? val.slice(0, 120) + "…  (" + val.length + " chars)" : val;
-    v.closest(".field").classList.remove("reveal");
+    const row = v.closest(".field");
+    row.classList.remove("reveal");
+    // Pubkey-only mode has no secrets etc. — hide rows with nothing to show.
+    row.style.display = val ? "" : "none";
+  }
+  // Hide groups whose rows are all hidden.
+  for (const g of groupsEl.children) {
+    const anyVisible = [...g.querySelectorAll(".field")].some((r) => r.style.display !== "none");
+    g.style.display = anyVisible ? "" : "none";
   }
   jsonEl.textContent = JSON.stringify(keys, null, 2);
   resultsEl.classList.add("on");
@@ -247,6 +257,7 @@ function classify(raw) {
   if (!s) return { mode: "random" };
   if (/^[0-9a-fA-F]{64}$/.test(s)) return { mode: "priv", value: s.toLowerCase() };
   if (/^nsec1[0-9a-z]+$/.test(s)) return { mode: "nsec", value: s };
+  if (/^npub1[0-9a-z]+$/.test(s)) return { mode: "pub", value: s };
   return { mode: "vanity", value: s.toLowerCase() };
 }
 
@@ -261,6 +272,9 @@ function generateFrom(cls) {
     } else if (cls.mode === "nsec") {
       const p = noskey.nsecToHex(cls.value);
       render(noskey.getAllKeys(p), `noskey -s ${short(cls.value)}`);
+    } else if (cls.mode === "pub") {
+      const pub = /^npub1/.test(cls.value) ? noskey.npubToHex(cls.value) : cls.value.toLowerCase();
+      render(noskey.getPubKeys(pub), `noskey --pub ${short(cls.value)}`);
     }
   } catch (e) {
     showErr("Couldn't derive keys from that input: " + e.message);
@@ -335,9 +349,17 @@ $("reveal").addEventListener("click", () => {
 $("toggle-json").addEventListener("click", () => jsonEl.classList.toggle("on"));
 $("copy-json").addEventListener("click", (e) => { if (lastKeys) copy(JSON.stringify(lastKeys, null, 2), e.target); });
 
-// boot
+// boot — a ?pubkey=<hex|npub> query param renders a shareable public view.
+// (Public keys only: never accept secrets via URL — they leak into history/logs.)
 goEl.disabled = false; goEl.textContent = "Generate";
-generateFrom({ mode: "random" });
+const qpub = new URLSearchParams(location.search).get("pubkey");
+if (qpub && (/^[0-9a-fA-F]{64}$/.test(qpub) || /^npub1[0-9a-z]+$/.test(qpub))) {
+  inputEl.value = qpub;
+  goEl.textContent = "Derive";
+  generateFrom({ mode: "pub", value: qpub });
+} else {
+  generateFrom({ mode: "random" });
+}
 </script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -354,9 +354,18 @@ $("copy-json").addEventListener("click", (e) => { if (lastKeys) copy(JSON.string
 goEl.disabled = false; goEl.textContent = "Generate";
 const qpub = new URLSearchParams(location.search).get("pubkey");
 if (qpub && (/^[0-9a-fA-F]{64}$/.test(qpub) || /^npub1[0-9a-z]+$/.test(qpub))) {
-  inputEl.value = qpub;
-  goEl.textContent = "Derive";
-  generateFrom({ mode: "pub", value: qpub });
+  try {
+    // Normalize the input box to the npub form: a raw 64-hex value would
+    // re-classify as a private key on the next Derive press and leak into
+    // getAllKeys — npub is unambiguous, so re-deriving stays public.
+    const hex = /^npub1/.test(qpub) ? noskey.npubToHex(qpub) : qpub.toLowerCase();
+    const npub = noskey.getPubKeys(hex).npub;
+    inputEl.value = npub;
+    goEl.textContent = "Derive";
+    generateFrom({ mode: "pub", value: npub });
+  } catch (e) {
+    showErr("Invalid pubkey in URL: " + e.message);
+  }
 } else {
   generateFrom({ mode: "random" });
 }


### PR DESCRIPTION
Closes #11.

## What

Derive everything that's a pure function of an x-only public key — without ever having the private key:

- **lib**: new `getPubKeys(publicKey)` → `pubkey`, `did:nostr`, `npub`, `nrepo`, and the five taproot encodings (`bc`/`tb`/`ex`/`ltc`/`vtc`). `getAllKeys()` unchanged. `pubkeycompressed` is deliberately excluded: y-parity is unknown from an x-only key, so a `02…` guess would silently disagree with `getAllKeys()` for ~half of all keys.
- **CLI**: `noskey --pub <hex|npub>` prints that subset.
- **web**: `?pubkey=<hex|npub>` query param renders a shareable public view (e.g. `…/web/?pubkey=npub1…` shows someone's addresses on every chain), and an `npub1…` pasted into the input box does the same. Secret/ed25519/SSH rows and groups are hidden. Private keys are never accepted via query string (URLs leak into history/logs).

## Verification

- `npm test`: 40/40 pass.
- `node test/verify-core.js` (extended): web-core `getPubKeys` diffed field-by-field against `node bin/noskey.js --pub` for hex and npub inputs across 3 keys — all match; plus a drift check that every `getPubKeys` field equals the corresponding `getAllKeys` field.
- Headless Chromium against the real page: `?pubkey=npub1…` and `?pubkey=<hex>` render the correct values with the `--pub` command echo, secret rows hidden, and zero `nsec` occurrences in the DOM; the default random view is unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive feature with input validation; no changes to private-key paths beyond new early-exit CLI branch and safer URL handling for public keys only.
> 
> **Overview**
> Adds **pubkey-only** derivation so users can show Nostr identifiers and multi-chain taproot encodings from an **x-only public key** (hex or `npub`) without ever handling a private key.
> 
> **lib** exports `getPubKeys()` for `pubkey`, `did:nostr`, `npub`, `nrepo`, and the five taproot variants; **`pubkeycompressed` is intentionally omitted** because y-parity cannot be recovered from x-only input. **CLI** adds `noskey --pub <hex|npub>`. **Web** accepts pasted `npub1…`, supports shareable `?pubkey=` links (public keys only—no secrets in URLs), normalizes hex query params to `npub` so re-derive cannot treat them as private keys, and hides secret/empty result rows. **Tests** cross-check web core vs CLI `--pub` and `getAllKeys` field parity; README documents the new flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab1b062df08548fc9901c8933cb5e892f332186a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->