### PR TITLE
Remove nrepo from getAllKeys/getPubKeys output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Generate nostr keys from command line
 &nbsp;&nbsp;✓&nbsp; Generate bitcoin address  
 &nbsp;&nbsp;✓&nbsp; Generate bitcoin testnet3 address  
 &nbsp;&nbsp;✓&nbsp; Generate npub Public Key  
-&nbsp;&nbsp;✓&nbsp; Generate nrepo Public Key  
 &nbsp;&nbsp;✓&nbsp; Generate taproot Public Key  
 &nbsp;&nbsp;✓&nbsp; Generate taproot test Public Key  
 &nbsp;&nbsp;✓&nbsp; Generate ed25519 Public Key  
@@ -107,7 +106,6 @@ Options:
   "bitcoinPubkey": "1LcHKWvoVW7ZXVtVf7cX3JS6hqvWNnphaB",
   "bitcoinTestnet3Pubkey": "n18Eca1nJXYpJcN7NgatsDeRZqXDJ8EwFD",
   "npub": "npub1xyz2l5auvptxt50f9t7uxwa4pkxcc3ef8ytrwn6949jlcwg2qvesle5tfn",
-  "nrepo": "nrepo1xyz2l5auvptxt50f9t7uxwa4pkxcc3ef8ytrwn6949jlcwg2qveskz7ewj",
   "taproot": "bc1p1xyz2l5auvptxt50f9t7uxwa4pkxcc3ef8ytrwn6949jlcwg2qvesx55cr2",
   "taproottestnet": "tb1p1xyz2l5auvptxt50f9t7uxwa4pkxcc3ef8ytrwn6949jlcwg2qves66y2cu",
   "liquidtaproot": "ex1p1xyz2l5auvptxt50f9t7uxwa4pkxcc3ef8ytrwn6949jlcwg2qvesdq02p7",

--- a/lib/index.js
+++ b/lib/index.js
@@ -679,7 +679,6 @@ ${END}`
  * @property {string} didnostr - The DID Nostr identifier in the format "did:nostr:<pubkey>".
  * @property {string} pubkeycompressed - The compressed public key generated from the private key.
  * @property {string} npub - The npub value for the public key.
- * @property {string} nrepo - The nrepo value for the public key.
  * @property {string} taproot - The taproot address generated from the public key.
  * @property {string} taproottestnet - The taproot testnet address generated from the public key.
  * @property {string} liquidtaproot - The liquid taproot address generated from the public key.
@@ -700,7 +699,6 @@ function getAllKeys(privateKey) {
 
   const publicKey = getPublicKey(privateKey)
   const npub = nip19(publicKey, 'npub')
-  const nrepo = nip19(publicKey, 'nrepo')
   // console.log(npub)
 
   // const ECPair = ECPairFactory(tiny)
@@ -731,7 +729,6 @@ function getAllKeys(privateKey) {
     // bitcoinPubkey: wif.address,
     // bitcoinTestnet3Pubkey: wifTestnet.address,
     npub,
-    nrepo,
     taproot: encodeBytes(taproot_prefix, publicKey),
     taproottestnet: encodeBytes(taproot_testnet_prefix, publicKey),
     liquidtaproot: encodeBytes(liquid_prefix, publicKey),
@@ -776,7 +773,6 @@ function getPubKeys(publicKey) {
     pubkey: publicKey,
     didnostr: `did:nostr:${publicKey}`,
     npub: nip19(publicKey, 'npub'),
-    nrepo: nip19(publicKey, 'nrepo'),
     taproot: encodeBytes(taproot_prefix, publicKey),
     taproottestnet: encodeBytes(taproot_testnet_prefix, publicKey),
     liquidtaproot: encodeBytes(liquid_prefix, publicKey),

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -81,7 +81,7 @@ describe('CLI: Output format', () => {
     // Should have all expected fields
     const expectedFields = [
       'privkey', 'nsec', 'pubkey', 'didnostr', 'pubkeycompressed',
-      'npub', 'nrepo', 'taproot', 'taproottestnet', 'liquidtaproot',
+      'npub', 'taproot', 'taproottestnet', 'liquidtaproot',
       'ed25519pubkey', 'pubky', 'mnemonic', 'bip86_tprv', 'bip86_tpub',
       'bip86_p2tr', 'openSSHed25519pubkey', 'openSSHed25519privkey'
     ]

--- a/web/assets/noskey-core.js
+++ b/web/assets/noskey-core.js
@@ -83,7 +83,7 @@ export function createNoskey(deps) {
     return secp.utils.bytesToHex(secp.schnorr.getPublicKey(privateKeyHex));
   }
 
-  // nostr nip-19 style bech32 (npub/nsec/nrepo), default limit
+  // nostr nip-19 style bech32 (npub/nsec), default limit
   function nip19(dataHex, prefix) {
     const words = bech32.toWords(hexToBytes(dataHex));
     return bech32.encode(prefix, words);
@@ -189,7 +189,6 @@ export function createNoskey(deps) {
 
     const publicKey = getPublicKey(privateKey);
     const npub = nip19(publicKey, "npub");
-    const nrepo = nip19(publicKey, "nrepo");
 
     const ed25519Keypair = nacl.sign.keyPair.fromSeed(hexToBytes(privateKey));
     const ed25519pubkey = bytesToHex(ed25519Keypair.publicKey);
@@ -210,7 +209,6 @@ export function createNoskey(deps) {
       didnostr: `did:nostr:${publicKey}`,
       pubkeycompressed: compressed,
       npub,
-      nrepo,
       taproot: encodeBytes(taproot_prefix, publicKey),
       taproottestnet: encodeBytes(taproot_testnet_prefix, publicKey),
       liquidtaproot: encodeBytes(liquid_prefix, publicKey),
@@ -257,7 +255,6 @@ export function createNoskey(deps) {
       pubkey: publicKey,
       didnostr: `did:nostr:${publicKey}`,
       npub: nip19(publicKey, "npub"),
-      nrepo: nip19(publicKey, "nrepo"),
       taproot: encodeBytes("bc", publicKey),
       taproottestnet: encodeBytes("tb", publicKey),
       liquidtaproot: encodeBytes("ex", publicKey),


### PR DESCRIPTION
Closes #13.

Removes the never-used `nrepo` field from the source of truth, everywhere it's emitted:

- `lib/index.js`: dropped from `getAllKeys()` and `getPubKeys()` output and JSDoc.
- `web/assets/noskey-core.js`: dropped from the mirrored functions, keeping the byte-for-byte web/CLI parity check green.
- `test/cli.test.js`: removed from the expected-fields list.
- `README.md`: removed the feature bullet and the example-output field.

Verified: `npm test` 40/40; `test/verify-core.js` all-pass (now 19 fields, matching both directions); CLI output contains no `nrepo`.

Note: breaking change to the JSON output shape — worth a version bump on next npm publish. The stale `lib/index.js.new`/`.saf` backup files and generated `docs/` still mention nrepo but are untouched here (already stale on other fronts).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes an unused output field only; no changes to key derivation or security-sensitive logic, but downstream parsers expecting `nrepo` will break until they adapt.
> 
> **Overview**
> Removes the unused **`nrepo`** bech32 field from noskey’s JSON output everywhere it was emitted, so CLI and browser stay aligned on the same shape.
> 
> **`getAllKeys()`** and **`getPubKeys()`** in `lib/index.js` no longer compute or return `nrepo`; JSDoc is updated. The browser mirror in `web/assets/noskey-core.js` matches, and CLI tests drop `nrepo` from the expected field list. **README** no longer lists or shows `nrepo` in the example JSON.
> 
> This is a **breaking change** for consumers that relied on `nrepo` in CLI/web JSON; a semver bump on publish is appropriate. Generated `docs/` and backup files still mention `nrepo` but are out of scope here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86fabb72c373bdc0227256562b627643c7d70c7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->